### PR TITLE
Bump d2l-date-picker dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "polymer": "Polymer/polymer#1.9 - 2",
     "d2l-time-picker": "BrightspaceUI/time-picker#^0.3.0",
     "d2l-date-picker": "BrightspaceUI/date-picker#^0.0.12",
-    "d2l-offscreen": "^2.2.5",
+    "d2l-offscreen": "^3.0.1",
     "app-localize-behavior": "0.10 - 2",
     "iron-input": "^1.0.0",
     "d2l-intl": "^0.4.1"

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#1.9 - 2",
     "d2l-time-picker": "BrightspaceUI/time-picker#^0.3.0",
-    "d2l-date-picker": "BrightspaceUI/date-picker#^0.0.11",
+    "d2l-date-picker": "BrightspaceUI/date-picker#^0.0.12",
     "d2l-offscreen": "^2.2.5",
     "app-localize-behavior": "0.10 - 2",
     "iron-input": "^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#1.9 - 2",
     "d2l-time-picker": "BrightspaceUI/time-picker#^0.3.0",
-    "d2l-date-picker": "BrightspaceUI/date-picker#^0.0.10",
+    "d2l-date-picker": "BrightspaceUI/date-picker#^0.0.11",
     "d2l-offscreen": "^2.2.5",
     "app-localize-behavior": "0.10 - 2",
     "iron-input": "^1.0.0",

--- a/bower.json
+++ b/bower.json
@@ -39,6 +39,8 @@
     }
   },
   "resolutions": {
-    "webcomponentsjs": "0.7 - 1"
+    "webcomponentsjs": "0.7 - 1",
+    "d2l-offscreen": "^3.0.1",
+    "d2l-polymer-behaviors": "^1.0.0"
   }
 }


### PR DESCRIPTION
Bump date-picker version so that it will use a version that shows the correct firstDayOfWeek and dateFormat.

Also added resolutions for d2l-offscreen and d2l-polymer behaviors:

> Unable to find a suitable version for d2l-offscreen, please choose one by typing
 one of the numbers below:
    1) d2l-offscreen#^2.2.5 which resolved to 2.2.5 and is required by d2l-datetime-picker
    2) d2l-offscreen#^2.2.4 which resolved to 2.2.5 and is required by d2l-dropdown#5.2.1
    3) d2l-offscreen#^2.2.1 which resolved to 2.2.5 and is required by d2l-icons#3.6.0
    4) d2l-offscreen#^3.0.1 which resolved to 3.0.1 and is required by d2l-date-picker#0.0.12```

> Unable to find a suitable version for d2l-polymer-behaviors, please choose one by typing one of the numbers below:
    1) d2l-polymer-behaviors#~0.0.5 which resolved to 0.0.5 and is required by d2l-dropdown#5.2.1, d2l-hierarchical-view#0.1.4
    2) d2l-polymer-behaviors#^1.0.0 which resolved to 1.0.0 and is required by d2l-date-picker#0.0.12`