### PR TITLE
fix height issue and missing attributes when used with hybrid version of d2l-icon-button

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
     "d2l-localize-behavior": "^1.0.1",
     "d2l-offscreen": "^3.0.1",
     "iron-input": "^1.0.0",
-    "d2l-intl": "^0.4.1"
+    "d2l-intl": "^0.4.1",
+    "d2l-icons": "^4.12.1"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#1 - 2",
@@ -51,6 +52,9 @@
   "resolutions": {
     "webcomponentsjs": "0.7 - 1",
     "d2l-offscreen": "^3.0.1",
-    "d2l-polymer-behaviors": "^1.0.0"
+    "d2l-polymer-behaviors": "^1.0.0",
+    "d2l-colors": "^3.1.2",
+    "d2l-icons": "^4.12.1",
+    "iron-iconset-svg": "^2.1.0"
   }
 }

--- a/d2l-datetime-picker.html
+++ b/d2l-datetime-picker.html
@@ -222,7 +222,6 @@ Accessible, Localized Time Picker Input Element
 						icon="d2l-tier1:close-small"
 						on-click="clear"
 						title="[[localize('clear')]]"
-						aria-label$="[[localize('clear')]]"
 					>
 						<button is="d2l-icon-button"
 							icon="d2l-tier1:close-small"

--- a/d2l-datetime-picker.html
+++ b/d2l-datetime-picker.html
@@ -85,6 +85,12 @@ Accessible, Localized Time Picker Input Element
 				height: 2.4rem;
 			}
 
+			.clear-button {
+				--d2l-icon-button-icon: {
+					height: 2.4rem;
+				};
+			}
+
 			:host([has-date]) d2l-date-picker {
 				padding-right: 1rem;
 				padding-bottom: 20px;
@@ -184,11 +190,11 @@ Accessible, Localized Time Picker Input Element
 		</style>
 		<div class="d2l-date-picker-container">
 			<label aria-hidden="true" role="presentation">[[_dateLabel]]</label>
-			<d2l-date-picker 
-				value="{{date}}" 
-				placeholder=[[placeholder]] 
-				label=[[_dateLabel]] 
-				locale=[[locale]] 
+			<d2l-date-picker
+				value="{{date}}"
+				placeholder=[[placeholder]]
+				label=[[_dateLabel]]
+				locale=[[locale]]
 				min=[[min]]
 				max=[[max]]
 				date-format=[[dateFormat]]
@@ -211,7 +217,13 @@ Accessible, Localized Time Picker Input Element
 					></d2l-time-picker>
 				</div>
 				<div class="clear-button-container">
-					<d2l-icon-button class="clear-button" icon="d2l-tier1:close-small">
+					<d2l-icon-button
+						class="clear-button"
+						icon="d2l-tier1:close-small"
+						on-click="clear"
+						title="[[localize('clear')]]"
+						aria-label$="[[localize('clear')]]"
+					>
 						<button is="d2l-icon-button"
 							icon="d2l-tier1:close-small"
 							on-click="clear"


### PR DESCRIPTION
Was testing this component with an updated version of assignments-ui which is in the process of being hybridized and is using d2l-icons v4.  The icon was always showing aligned to the top of the button rather than centred, and the click handler was not firing.

Is there a reason why you didn't declare an explicit dependency on d2l-icons in this component?  It seems a bit weird given it directly uses d2l-icon-button? I realize that would require a consumer to add a resolution to use the d2l-icons v3. Was it explicitly omitted to make it easier to use with both v3 and v4 of d2l-icons.