### PR TITLE
use timezone identifier from localize instead of moment.tz.guess()

### DIFF
--- a/d2l-datetime-picker.html
+++ b/d2l-datetime-picker.html
@@ -191,7 +191,7 @@ Accessible, Localized Time Picker Input Element
 						label="[[_timeLabel]]"
 						locale="[[locale]]"
 						overrides="[[overrides]]"
-						timezone="[[_getTimezone(timezone, timezoneName)]]"
+						timezone="[[_getTimezone(__timezone, timezoneName)]]"
 						hours="{{hours}}"
 						minutes="{{minutes}}"
 						boundary="[[boundary]]"
@@ -232,11 +232,6 @@ Accessible, Localized Time Picker Input Element
 					notify: true
 				},
 				overrides: Object,
-				timezone: {
-					type: String,
-					value: moment.tz.guess(),
-					notify: true
-				},
 				timezoneName: {
 					type: String,
 					value: ''
@@ -292,7 +287,7 @@ Accessible, Localized Time Picker Input Element
 			},
 
 			observers: [
-				'_dateAndTimeChanged(date, timezone, hours, minutes)',
+				'_dateAndTimeChanged(date, timezoneIdentifier, hours, minutes)',
 				'_processOverrides(overrides)'
 			],
 
@@ -305,7 +300,7 @@ Accessible, Localized Time Picker Input Element
 					this.date = '';
 					return;
 				}
-				datetime = moment.tz(datetime, this.timezone);
+				datetime = moment.tz(datetime, this.timezoneIdentifier);
 				if (!datetime.isValid()) {
 					return;
 				}
@@ -327,7 +322,7 @@ Accessible, Localized Time Picker Input Element
 				}
 				var datetime;
 				try {
-					datetime = moment.tz(this.date, this.timezone);
+					datetime = moment.tz(this.date, this.timezoneIdentifier);
 					if (!datetime.isValid()) {
 						return;
 					}


### PR DESCRIPTION
Fixes https://trello.com/c/hqnjqI83/25-assignment-due-date-time-not-accounting-for-timezone-properly and is dependent on https://github.com/BrightspaceUI/localize-behavior/pull/19