### PR TITLE
use timezone identifier from localize instead of moment.tz.guess()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
 - |
   if [ $TRAVIS_PULL_REQUEST != false ] && [ $TRAVIS_SECURE_ENV_VARS == true ]; then
     echo "Pull request with secure environment variables, running Sauce tests...";
-    npm run test:polymer:sauce && npm run test:galen:sauce || travis_terminate 1;
+    npm run test:polymer:sauce || travis_terminate 1;
   else
     echo "Not a pull request and/or no secure environment variables, running headless tests...";
     npm run test:polymer:local || travis_terminate 1;

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "d2l-button": "^4.4.0",
     "d2l-date-picker": "BrightspaceUI/date-picker#^1.0.0",
     "d2l-icons": "^5.0.1",
-    "d2l-localize-behavior": "^1.0.1",
+    "d2l-localize-behavior": "^1.1.4",
     "d2l-offscreen": "^3.0.1",
     "d2l-time-picker": "BrightspaceUI/time-picker#^1.0.0",
     "iron-input": "^2.0.0",

--- a/d2l-datetime-picker.html
+++ b/d2l-datetime-picker.html
@@ -191,7 +191,7 @@ Accessible, Localized Time Picker Input Element
 						label="[[_timeLabel]]"
 						locale="[[locale]]"
 						overrides="[[overrides]]"
-						timezone="[[_getTimezone(timezone, timezoneName)]]"
+						timezone="[[_getTimezone(__timezone, timezoneName)]]"
 						hours="{{hours}}"
 						minutes="{{minutes}}"
 						boundary="[[boundary]]"
@@ -232,11 +232,6 @@ Accessible, Localized Time Picker Input Element
 					notify: true
 				},
 				overrides: Object,
-				timezone: {
-					type: String,
-					value: moment.tz.guess(),
-					notify: true
-				},
 				timezoneName: {
 					type: String,
 					value: ''
@@ -292,7 +287,7 @@ Accessible, Localized Time Picker Input Element
 			},
 
 			observers: [
-				'_dateAndTimeChanged(date, timezone, hours, minutes)',
+				'_dateAndTimeChanged(date, timezoneIdentifier, hours, minutes)',
 				'_processOverrides(overrides)'
 			],
 
@@ -305,7 +300,7 @@ Accessible, Localized Time Picker Input Element
 					this.date = '';
 					return;
 				}
-				datetime = moment.tz(datetime, this.timezone);
+				datetime = moment.tz(datetime, this.timezoneIdentifier);
 				if (!datetime.isValid()) {
 					return;
 				}
@@ -327,7 +322,7 @@ Accessible, Localized Time Picker Input Element
 				}
 				var datetime;
 				try {
-					datetime = moment.tz(this.date, this.timezone);
+					datetime = moment.tz(this.date, this.timezoneIdentifier);
 					if (!datetime.isValid()) {
 						return;
 					}

--- a/d2l-datetime-picker.html
+++ b/d2l-datetime-picker.html
@@ -191,7 +191,7 @@ Accessible, Localized Time Picker Input Element
 						label="[[_timeLabel]]"
 						locale="[[locale]]"
 						overrides="[[overrides]]"
-						timezone="[[_getTimezone(__timezone, timezoneName)]]"
+						timezone="[[timezoneName]]"
 						hours="{{hours}}"
 						minutes="{{minutes}}"
 						boundary="[[boundary]]"
@@ -287,12 +287,21 @@ Accessible, Localized Time Picker Input Element
 			},
 
 			observers: [
-				'_dateAndTimeChanged(date, timezoneIdentifier, hours, minutes)',
+				'_dateAndTimeChanged(date, timezoneName, hours, minutes)',
 				'_processOverrides(overrides)'
 			],
 
+			listeners: {
+				'd2l-localize-behavior-timezone-changed': '_handleTimezoneChange',
+			},
+
 			clear: function() {
 				this.datetime = '';
+			},
+
+			_handleTimezoneChange: function() {
+				this.timezoneName = this.getTimezone() && this.getTimezone().name;
+				this._dateAndTimeChanged();
 			},
 
 			_dateTimeChanged: function(datetime) {
@@ -300,7 +309,8 @@ Accessible, Localized Time Picker Input Element
 					this.date = '';
 					return;
 				}
-				datetime = moment.tz(datetime, this.timezoneIdentifier);
+				datetime = moment.tz(datetime, this.getTimezone() && this.getTimezone().identifier);
+
 				if (!datetime.isValid()) {
 					return;
 				}
@@ -322,7 +332,7 @@ Accessible, Localized Time Picker Input Element
 				}
 				var datetime;
 				try {
-					datetime = moment.tz(this.date, this.timezoneIdentifier);
+					datetime = moment.tz(this.date, this.getTimezone() && this.getTimezone().identifier);
 					if (!datetime.isValid()) {
 						return;
 					}
@@ -344,10 +354,6 @@ Accessible, Localized Time Picker Input Element
 
 			_computeHasDate: function(datetime) {
 				return !!datetime;
-			},
-
-			_getTimezone: function(timezone, timezoneName) {
-				return timezoneName || timezone;
 			},
 
 			_showTime: function(date, alwaysShowTime) {

--- a/demo/galen.html
+++ b/demo/galen.html
@@ -39,7 +39,7 @@
 					document.body.style.width = match[1];
 				}
 				if (window.location.href.indexOf('dir=rtl') > -1) {
-					document.body.setAttribute('dir', 'rtl');
+					document.documentElement.setAttribute('dir', 'rtl');
 				}
 				document.body.className = 'd2l-typography';
 			})();

--- a/demo/index.html
+++ b/demo/index.html
@@ -29,7 +29,7 @@
 			<template is="dom-bind">
 				<label>Locale: <input value="{{locale::input}}"/></label>
 				<br/>
-				<label>Timezone: <input value="{{timezone::input}}"/></label>
+				<label>Timezone: <input value="{{timezoneName::input}}"/></label>
 				<br/>
 				<label>Placeholder: <input value="{{placeholder::input}}" type="text"/></label>
 				<br/>
@@ -47,7 +47,7 @@
 				<br/>
 				<d2l-datetime-picker
 					locale="{{locale}}"
-					timezone="{{timezone}}"
+					timezone-name="{{timezoneName}}"
 					placeholder="{{placeholder}}"
 					datetime="{{datetime}}"
 					date="{{date}}"

--- a/test/acceptance/galen.test.js
+++ b/test/acceptance/galen.test.js
@@ -47,7 +47,7 @@ var browsers = {
 var mainlineEndpoint = 'http://localhost:8081/components/d2l-datetime-picker/demo/galen.html';
 var oneDotXEndpoint = 'http://localhost:8000/components/d2l-datetime-picker/demo/galen.html';
 
-var rtlScript = 'document.body.setAttribute("dir", "rtl");';
+var rtlScript = 'document.documentElement.setAttribute("dir", "rtl");';
 var getInput = 'document.querySelector("d2l-datetime-picker").$$("d2l-date-picker").$$(".d2l-input")';
 var inputClickScript = getInput + '.dispatchEvent(new MouseEvent("click"))';
 var typeDateScript = getInput + '.value= "01/30/1990"';

--- a/test/d2l-datetime-picker_test.html
+++ b/test/d2l-datetime-picker_test.html
@@ -163,7 +163,7 @@
 
 			suite('timezone', function() {
 				test('utcdatetime is converted to UTC from the given timezone (UTC)', function() {
-					this.element.timezone = 'UTC';
+					this.element.__timezoneObject = {name: '', identifier: 'UTC'};
 					this.element.date = '1990-01-30';
 					this.element.hours = 1;
 					this.element.minutes = 30;
@@ -174,7 +174,7 @@
 				});
 
 				test('utcdatetime is converted to UTC from the given timezone (America/Toronto)', function() {
-					this.element.timezone = 'America/Toronto';
+					this.element.__timezoneObject = {name: '', identifier: 'America/Toronto'};
 					this.element.date = '1990-01-30';
 					this.element.hours = 1;
 					this.element.minutes = 30;
@@ -185,7 +185,7 @@
 				});
 
 				test('utcdatetime is converted to UTC from the given timezone (America/Los_Angeles)', function() {
-					this.element.timezone = 'America/Los_Angeles';
+					this.element.__timezoneObject = {name: '', identifier: 'America/Los_Angeles'};
 					this.element.date = '1990-01-30';
 					this.element.hours = 1;
 					this.element.minutes = 30;
@@ -196,12 +196,12 @@
 				});
 
 				test('changing timezone will not update date/hours/minutes', function() {
-					this.element.timezone = 'America/Toronto';
+					this.element.__timezoneObject = {name: '', identifier: 'America/Toronto'};
 					this.element.date = '1990-01-30';
 					this.element.hours = 1;
 					this.element.minutes = 30;
 
-					this.element.timezone = 'UTC';
+					this.element.__timezoneObject = {name: '', identifier: 'UTC'};
 
 					expect(this.element.date).to.equal('1990-01-30');
 					expect(this.element.hours).to.equal(1);
@@ -209,12 +209,12 @@
 				});
 
 				test('changing timezone will not update date/hours/minutes', function() {
-					this.element.timezone = 'UTC';
+					this.element.__timezoneObject = {name: '', identifier: 'UTC'};
 					this.element.date = '1990-01-30';
 					this.element.hours = 23;
 					this.element.minutes = 30;
 
-					this.element.timezone = 'America/Toronto';
+					this.element.__timezoneObject = {name: '', identifier: 'America/Toronto'};
 
 					expect(this.element.date).to.equal('1990-01-30');
 					expect(this.element.hours).to.equal(23);
@@ -222,7 +222,7 @@
 				});
 
 				test('changing timezone will update datetime', function() {
-					this.element.timezone = 'America/Toronto';
+					this.element.__timezoneObject = {name: '', identifier: 'America/Toronto'};
 					this.element.date = '1990-01-30';
 					this.element.hours = 1;
 					this.element.minutes = 30;
@@ -231,7 +231,7 @@
 					expect(this.element.datetime.utc().minutes()).to.equal(30);
 					expect(this.element.datetime.utc().date()).to.equal(30);
 
-					this.element.timezone = 'UTC';
+					this.element.__timezoneObject = {name: '', identifier: 'UTC'};
 
 					expect(this.element.datetime.utc().hours()).to.equal(1);
 					expect(this.element.datetime.utc().minutes()).to.equal(30);


### PR DESCRIPTION
Fixes https://trello.com/c/hqnjqI83/25-assignment-due-date-time-not-accounting-for-timezone-properly and is dependent on BrightspaceUI/localize-behavior#19