### PR TITLE
US110582 Emit event when date is cleared

### DIFF
--- a/d2l-datetime-picker.js
+++ b/d2l-datetime-picker.js
@@ -300,6 +300,7 @@ Polymer({
 
 	clear: function() {
 		this.datetime = null;
+		this.fire('d2l-datetime-picker-datetime-cleared');
 	},
 
 	_dateTimeChanged: function(datetime) {


### PR DESCRIPTION
This is being used for an activity due date, which can validly be null - when the field is cleared, though (i.e. setting no due date), no event is emitted. This adds a new event, `d2l-datetime-picker-datetime-cleared`, when the Clear button is clicked. (Using a new event to avoid affecting existing behaviour of the `d2l-datetime-picker-datetime-changed` event, as handlers may assume there is a value associated with that event.)