### PR TITLE
US113165 Add invalid/error styling

### DIFF
--- a/d2l-datetime-picker.js
+++ b/d2l-datetime-picker.js
@@ -154,6 +154,10 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-datetime-picker">
 				margin-top: -26px;
 			}
 
+			:host([timezone-name]:not([timezone-name=""])) d2l-tooltip {
+				margin-top: calc(-1.2rem - 16px);
+			}
+
 			:host([tooltip-red]) d2l-tooltip {
 				--d2l-tooltip-background-color: var(--d2l-color-cinnabar);
 				--d2l-tooltip-border-color: var(--d2l-color-cinnabar);
@@ -259,7 +263,8 @@ Polymer({
 			type: String,
 			value: function() {
 				return this.getTimezone() && this.getTimezone().name;
-			}
+			},
+			reflectToAttribute: true
 		},
 		hasDate: {
 			type: Boolean,

--- a/d2l-datetime-picker.js
+++ b/d2l-datetime-picker.js
@@ -12,7 +12,7 @@ import 'd2l-date-picker/d2l-date-picker.js';
 import 'd2l-icons/tier1-icons.js';
 import 'd2l-offscreen/d2l-offscreen.js';
 import 'd2l-time-picker/d2l-time-picker.js';
-import 'd2l-tooltip/d2l-tooltip';
+import 'd2l-tooltip/d2l-tooltip.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@polymer/iron-input/iron-input.js';
 import './localize-behavior.js';
@@ -154,7 +154,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-datetime-picker">
 				margin-top: -26px;
 			}
 
-			:host([timezone-name]:not([timezone-name=""])) d2l-tooltip {
+			:host([has-date][timezone-name]:not([timezone-name=""])) d2l-tooltip {
 				margin-top: calc(-1.2rem - 16px);
 			}
 

--- a/d2l-datetime-picker.js
+++ b/d2l-datetime-picker.js
@@ -146,18 +146,6 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-datetime-picker">
 				display: none;
 			}
 
-			d2l-tooltip {
-				margin-top: -6px;
-			}
-
-			:host([has-date]) d2l-tooltip {
-				margin-top: -26px;
-			}
-
-			:host([has-date][timezone-name]:not([timezone-name=""])) d2l-tooltip {
-				margin-top: calc(-1.2rem - 16px);
-			}
-
 			:host([tooltip-red]) d2l-tooltip {
 				--d2l-tooltip-background-color: var(--d2l-color-cinnabar);
 				--d2l-tooltip-border-color: var(--d2l-color-cinnabar);
@@ -233,6 +221,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-datetime-picker">
 			<d2l-tooltip
 				position="[[position]]"
 				boundary="[[boundary]]"
+				offset="[[_getTooltipOffset(hasDate, timezoneName)]]"
 			>
 				[[invalid]]
 			</d2l-tooltip>
@@ -263,8 +252,7 @@ Polymer({
 			type: String,
 			value: function() {
 				return this.getTimezone() && this.getTimezone().name;
-			},
-			reflectToAttribute: true
+			}
 		},
 		hasDate: {
 			type: Boolean,
@@ -389,5 +377,17 @@ Polymer({
 
 	_computeIsInvalid: function(invalid) {
 		return !!invalid;
+	},
+
+	_getTooltipOffset: function(hasDate, timezoneName) {
+		if (hasDate && timezoneName && timezoneName.length > 0) {
+			return -27;
+		}
+
+		if (hasDate) {
+			return -18;
+		}
+
+		return 2;
 	}
 });

--- a/d2l-datetime-picker.js
+++ b/d2l-datetime-picker.js
@@ -12,6 +12,8 @@ import 'd2l-date-picker/d2l-date-picker.js';
 import 'd2l-icons/tier1-icons.js';
 import 'd2l-offscreen/d2l-offscreen.js';
 import 'd2l-time-picker/d2l-time-picker.js';
+import 'd2l-tooltip/d2l-tooltip';
+import '@brightspace-ui/core/components/colors/colors.js';
 import '@polymer/iron-input/iron-input.js';
 import './localize-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
@@ -144,6 +146,19 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-datetime-picker">
 				display: none;
 			}
 
+			d2l-tooltip {
+				margin-top: -6px;
+			}
+
+			:host([has-date]) d2l-tooltip {
+				margin-top: -26px;
+			}
+
+			:host([tooltip-red]) d2l-tooltip {
+				--d2l-tooltip-background-color: var(--d2l-color-cinnabar);
+				--d2l-tooltip-border-color: var(--d2l-color-cinnabar);
+			}
+
 			@media (max-width: 615px), (max-device-width: 960px) {
 				label {
 					font-size: 0.6rem;
@@ -177,11 +192,13 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-datetime-picker">
 		<div class="d2l-date-picker-container">
 			<label aria-hidden="true" role="presentation">[[_dateLabel]]</label>
 			<d2l-date-picker
+				id="date-picker"
 				value="{{date}}"
 				placeholder="[[placeholder]]"
 				label="[[_dateLabel]]"
 				min="[[min]]"
-				max="[[max]]">
+				max="[[max]]"
+				invalid="[[_computeIsInvalid(invalid)]]">
 			</d2l-date-picker>
 		</div>
 
@@ -194,7 +211,8 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-datetime-picker">
 						timezone="[[timezoneName]]"
 						hours="{{hours}}"
 						minutes="{{minutes}}"
-						boundary="[[boundary]]">
+						boundary="[[boundary]]"
+						invalid="[[_computeIsInvalid(invalid)]]">
 					</d2l-time-picker>
 				</div>
 				<div class="clear-button-container">
@@ -206,6 +224,14 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-datetime-picker">
 					</d2l-button-icon>
 				</div>
 			</div>
+		</template>
+		<template is="dom-if" if="[[_computeIsInvalid(invalid)]]">
+			<d2l-tooltip
+				position="[[position]]"
+				boundary="[[boundary]]"
+			>
+				[[invalid]]
+			</d2l-tooltip>
 		</template>
 	</template>
 </dom-module>`;
@@ -281,6 +307,14 @@ Polymer({
 		},
 		max: {
 			type: String
+		},
+		invalid: {
+			type: String,
+			value: null
+		},
+		position: {
+			type: String,
+			value: 'bottom'
 		}
 	},
 
@@ -346,5 +380,9 @@ Polymer({
 
 	_showTime: function(date, alwaysShowTime) {
 		return alwaysShowTime || date;
+	},
+
+	_computeIsInvalid: function(invalid) {
+		return !!invalid;
 	}
 });

--- a/demo/index.html
+++ b/demo/index.html
@@ -71,7 +71,9 @@
 							<br>
 							<label>Minutes: <input value="{{minutes::input}}" type="text"></label>
 							<br>
-							<d2l-datetime-picker timezone-name="{{__timezone}}" placeholder="{{placeholder}}" datetime="{{datetime}}" date="{{date}}" hours="{{hours}}" minutes="{{minutes}}" boundary="{&quot;below&quot;:240}" date-label="{{dateLabel}}" time-label="{{timeLabel}}"></d2l-datetime-picker>
+							<label>Invalid: <input value="{{invalid::input}}" type="text"></label> (note: tooltip is set to be red)
+							<br>
+							<d2l-datetime-picker tooltip-red invalid="{{invalid}}" timezone-name="{{__timezone}}" placeholder="{{placeholder}}" datetime="{{datetime}}" date="{{date}}" hours="{{hours}}" minutes="{{minutes}}" boundary="{&quot;below&quot;:240}" date-label="{{dateLabel}}" time-label="{{timeLabel}}"></d2l-datetime-picker>
 							<br>
 						</template>
 					</dom-bind>`;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "main": "d2l-datetime-picker.js",
   "dependencies": {
+    "@brightspace-ui/core": "^1.31.0",
     "@brightspace-ui/intl": "^3",
     "@polymer/iron-input": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
@@ -48,6 +49,7 @@
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "d2l-time-picker": "BrightspaceUI/time-picker#semver:^2",
+    "d2l-tooltip": "github:BrightspaceUI/tooltip#semver:^3",
     "d2l-typography": "BrightspaceUI/typography#semver:^7"
   }
 }

--- a/test/d2l-datetime-picker_test.html
+++ b/test/d2l-datetime-picker_test.html
@@ -43,20 +43,20 @@
 					const element = fixture('basic');
 					expect(element.$$('d2l-time-picker')).to.not.be.ok;
 					element.date = '1990-01-30';
-					requestIdleCallback(() => {
+					setTimeout(() => {
 						flush();
 						expect(element.$$('d2l-time-picker')).to.be.ok;
-					});
+					}, 0);
 				});
 
 				test('should have d2l-time-picker when alwaysShowTime is set', function() {
 					const element = fixture('basic');
 					expect(element.$$('d2l-time-picker')).to.not.be.ok;
 					element.alwaysShowTime = true;
-					requestIdleCallback(() => {
+					setTimeout(() => {
 						flush();
 						expect(element.$$('d2l-time-picker')).to.be.ok;
-					});
+					}, 0);
 				});
 
 				test('should have d2l-date-picker', function() {
@@ -68,14 +68,14 @@
 					test('should update time-picker hours/minutes', function() {
 						const element = fixture('basic');
 						element.date = '1990-01-30';
-						requestIdleCallback(() => {
+						setTimeout(() => {
 							flush();
 							element.hours = 1;
 							element.minutes = 30;
 
 							expect(element.$$('d2l-time-picker').hours).to.equal(1);
 							expect(element.$$('d2l-time-picker').minutes).to.equal(30);
-						});
+						}, 0);
 					});
 				});
 
@@ -98,19 +98,19 @@
 					test('should be updated when date is defined', function() {
 						const element = fixture('basic');
 						element.date = '1990-01-30';
-						requestIdleCallback(() => {
+						setTimeout(() => {
 							flush();
 							expect(element.datetime).to.be.ok;
 							expect(element.datetime.year()).to.equal(1990);
 							expect(element.datetime.month()).to.equal(0);
 							expect(element.datetime.date()).to.equal(30);
-						});
+						}, 0);
 					});
 
 					test('should have correct time', function() {
 						const element = fixture('basic');
 						element.date = '1990-01-30';
-						requestIdleCallback(() => {
+						setTimeout(() => {
 							flush();
 							element.hours = 1;
 							element.minutes = 30;
@@ -120,7 +120,7 @@
 							expect(element.datetime.date()).to.equal(30);
 							expect(element.datetime.hours()).to.equal(1);
 							expect(element.datetime.minutes()).to.equal(30);
-						});
+						}, 0);
 					});
 
 					test('date,hours,minutes should be updated when set', function() {
@@ -168,11 +168,11 @@
 					test('clears datetime', function() {
 						const element = fixture('basic');
 						element.datetime = moment();
-						requestIdleCallback(() => {
+						setTimeout(() => {
 							flush();
 							element.$$('d2l-button-icon').click();
 							expect(element.datetime).to.be.null;
-						});
+						}, 0);
 					});
 				});
 
@@ -197,11 +197,11 @@
 						element.hours = 1;
 						element.minutes = 30;
 
-						requestIdleCallback(() => {
+						setTimeout(() => {
 							expect(element.datetime.utc().hours()).to.equal(6);
 							expect(element.datetime.utc().minutes()).to.equal(30);
 							expect(element.datetime.utc().date()).to.equal(30);
-						});
+						}, 0);
 					});
 
 					test('utcdatetime is converted to UTC from the given timezone (America/Los_Angeles)', function() {
@@ -211,11 +211,11 @@
 						element.hours = 1;
 						element.minutes = 30;
 
-						requestIdleCallback(() => {
+						setTimeout(() => {
 							expect(element.datetime.utc().hours()).to.equal(9);
 							expect(element.datetime.utc().minutes()).to.equal(30);
 							expect(element.datetime.utc().date()).to.equal(30);
-						});
+						}, 0);
 					});
 
 					test('changing timezone will not update date/hours/minutes', function() {

--- a/test/d2l-datetime-picker_test.html
+++ b/test/d2l-datetime-picker_test.html
@@ -43,16 +43,20 @@
 					const element = fixture('basic');
 					expect(element.$$('d2l-time-picker')).to.not.be.ok;
 					element.date = '1990-01-30';
-					flush();
-					expect(element.$$('d2l-time-picker')).to.be.ok;
+					requestIdleCallback(() => {
+						flush();
+						expect(element.$$('d2l-time-picker')).to.be.ok;
+					});
 				});
 
 				test('should have d2l-time-picker when alwaysShowTime is set', function() {
 					const element = fixture('basic');
 					expect(element.$$('d2l-time-picker')).to.not.be.ok;
 					element.alwaysShowTime = true;
-					flush();
-					expect(element.$$('d2l-time-picker')).to.be.ok;
+					requestIdleCallback(() => {
+						flush();
+						expect(element.$$('d2l-time-picker')).to.be.ok;
+					});
 				});
 
 				test('should have d2l-date-picker', function() {
@@ -64,12 +68,14 @@
 					test('should update time-picker hours/minutes', function() {
 						const element = fixture('basic');
 						element.date = '1990-01-30';
-						flush();
-						element.hours = 1;
-						element.minutes = 30;
+						requestIdleCallback(() => {
+							flush();
+							element.hours = 1;
+							element.minutes = 30;
 
-						expect(element.$$('d2l-time-picker').hours).to.equal(1);
-						expect(element.$$('d2l-time-picker').minutes).to.equal(30);
+							expect(element.$$('d2l-time-picker').hours).to.equal(1);
+							expect(element.$$('d2l-time-picker').minutes).to.equal(30);
+						});
 					});
 				});
 
@@ -92,25 +98,29 @@
 					test('should be updated when date is defined', function() {
 						const element = fixture('basic');
 						element.date = '1990-01-30';
-						flush();
-						expect(element.datetime).to.be.ok;
-						expect(element.datetime.year()).to.equal(1990);
-						expect(element.datetime.month()).to.equal(0);
-						expect(element.datetime.date()).to.equal(30);
+						requestIdleCallback(() => {
+							flush();
+							expect(element.datetime).to.be.ok;
+							expect(element.datetime.year()).to.equal(1990);
+							expect(element.datetime.month()).to.equal(0);
+							expect(element.datetime.date()).to.equal(30);
+						});
 					});
 
 					test('should have correct time', function() {
 						const element = fixture('basic');
 						element.date = '1990-01-30';
-						flush();
-						element.hours = 1;
-						element.minutes = 30;
-						expect(element.datetime).to.be.ok;
-						expect(element.datetime.year()).to.equal(1990);
-						expect(element.datetime.month()).to.equal(0);
-						expect(element.datetime.date()).to.equal(30);
-						expect(element.datetime.hours()).to.equal(1);
-						expect(element.datetime.minutes()).to.equal(30);
+						requestIdleCallback(() => {
+							flush();
+							element.hours = 1;
+							element.minutes = 30;
+							expect(element.datetime).to.be.ok;
+							expect(element.datetime.year()).to.equal(1990);
+							expect(element.datetime.month()).to.equal(0);
+							expect(element.datetime.date()).to.equal(30);
+							expect(element.datetime.hours()).to.equal(1);
+							expect(element.datetime.minutes()).to.equal(30);
+						});
 					});
 
 					test('date,hours,minutes should be updated when set', function() {
@@ -158,9 +168,11 @@
 					test('clears datetime', function() {
 						const element = fixture('basic');
 						element.datetime = moment();
-						flush();
-						element.$$('d2l-button-icon').click();
-						expect(element.datetime).to.be.null;
+						requestIdleCallback(() => {
+							flush();
+							element.$$('d2l-button-icon').click();
+							expect(element.datetime).to.be.null;
+						});
 					});
 				});
 
@@ -185,9 +197,11 @@
 						element.hours = 1;
 						element.minutes = 30;
 
-						expect(element.datetime.utc().hours()).to.equal(6);
-						expect(element.datetime.utc().minutes()).to.equal(30);
-						expect(element.datetime.utc().date()).to.equal(30);
+						requestIdleCallback(() => {
+							expect(element.datetime.utc().hours()).to.equal(6);
+							expect(element.datetime.utc().minutes()).to.equal(30);
+							expect(element.datetime.utc().date()).to.equal(30);
+						});
 					});
 
 					test('utcdatetime is converted to UTC from the given timezone (America/Los_Angeles)', function() {
@@ -197,9 +211,11 @@
 						element.hours = 1;
 						element.minutes = 30;
 
-						expect(element.datetime.utc().hours()).to.equal(9);
-						expect(element.datetime.utc().minutes()).to.equal(30);
-						expect(element.datetime.utc().date()).to.equal(30);
+						requestIdleCallback(() => {
+							expect(element.datetime.utc().hours()).to.equal(9);
+							expect(element.datetime.utc().minutes()).to.equal(30);
+							expect(element.datetime.utc().date()).to.equal(30);
+						});
 					});
 
 					test('changing timezone will not update date/hours/minutes', function() {

--- a/test/d2l-datetime-picker_test.html
+++ b/test/d2l-datetime-picker_test.html
@@ -39,23 +39,25 @@
 					expect(element.is).to.equal('d2l-datetime-picker');
 				});
 
-				test('should have d2l-time-picker when date is set', function() {
+				test('should have d2l-time-picker when date is set', function(done) {
 					const element = fixture('basic');
 					expect(element.$$('d2l-time-picker')).to.not.be.ok;
 					element.date = '1990-01-30';
 					setTimeout(() => {
 						flush();
 						expect(element.$$('d2l-time-picker')).to.be.ok;
+						done();
 					}, 0);
 				});
 
-				test('should have d2l-time-picker when alwaysShowTime is set', function() {
+				test('should have d2l-time-picker when alwaysShowTime is set', function(done) {
 					const element = fixture('basic');
 					expect(element.$$('d2l-time-picker')).to.not.be.ok;
 					element.alwaysShowTime = true;
 					setTimeout(() => {
 						flush();
 						expect(element.$$('d2l-time-picker')).to.be.ok;
+						done();
 					}, 0);
 				});
 
@@ -65,7 +67,7 @@
 				});
 
 				suite('hours/minutes', function() {
-					test('should update time-picker hours/minutes', function() {
+					test('should update time-picker hours/minutes', function(done) {
 						const element = fixture('basic');
 						element.date = '1990-01-30';
 						setTimeout(() => {
@@ -75,6 +77,7 @@
 
 							expect(element.$$('d2l-time-picker').hours).to.equal(1);
 							expect(element.$$('d2l-time-picker').minutes).to.equal(30);
+							done();
 						}, 0);
 					});
 				});
@@ -95,7 +98,7 @@
 						expect(element.datetime).to.not.be.ok;
 					});
 
-					test('should be updated when date is defined', function() {
+					test('should be updated when date is defined', function(done) {
 						const element = fixture('basic');
 						element.date = '1990-01-30';
 						setTimeout(() => {
@@ -104,10 +107,11 @@
 							expect(element.datetime.year()).to.equal(1990);
 							expect(element.datetime.month()).to.equal(0);
 							expect(element.datetime.date()).to.equal(30);
+							done();
 						}, 0);
 					});
 
-					test('should have correct time', function() {
+					test('should have correct time', function(done) {
 						const element = fixture('basic');
 						element.date = '1990-01-30';
 						setTimeout(() => {
@@ -120,6 +124,7 @@
 							expect(element.datetime.date()).to.equal(30);
 							expect(element.datetime.hours()).to.equal(1);
 							expect(element.datetime.minutes()).to.equal(30);
+							done();
 						}, 0);
 					});
 
@@ -165,19 +170,20 @@
 				});
 
 				suite('d2l-button-icon', function() {
-					test('clears datetime', function() {
+					test('clears datetime', function(done) {
 						const element = fixture('basic');
 						element.datetime = moment();
 						setTimeout(() => {
 							flush();
 							element.$$('d2l-button-icon').click();
 							expect(element.datetime).to.be.null;
+							done();
 						}, 0);
 					});
 				});
 
 				suite('timezone', function() {
-					test('utcdatetime is converted to UTC from the given timezone (UTC)', function() {
+					test('utcdatetime is converted to UTC from the given timezone (UTC)', function(done) {
 
 						htmlElem.setAttribute('data-timezone', JSON.stringify({ name: '', identifier: 'UTC' }));
 						const element = fixture('basic');
@@ -188,33 +194,36 @@
 						expect(element.datetime.utc().hours()).to.equal(1);
 						expect(element.datetime.utc().minutes()).to.equal(30);
 						expect(element.datetime.utc().date()).to.equal(30);
+						done();
 					});
 
-					test('utcdatetime is converted to UTC from the given timezone (America/Toronto)', function() {
+					test('utcdatetime is converted to UTC from the given timezone (America/Toronto)', function(done) {
 						htmlElem.setAttribute('data-timezone', JSON.stringify({ name: '', identifier: 'America/Toronto' }));
-						const element = fixture('basic');
-						element.date = '1990-01-30';
-						element.hours = 1;
-						element.minutes = 30;
-
 						setTimeout(() => {
+							const element = fixture('basic');
+							element.date = '1990-01-30';
+							element.hours = 1;
+							element.minutes = 30;
+
 							expect(element.datetime.utc().hours()).to.equal(6);
 							expect(element.datetime.utc().minutes()).to.equal(30);
 							expect(element.datetime.utc().date()).to.equal(30);
+							done();
 						}, 0);
 					});
 
-					test('utcdatetime is converted to UTC from the given timezone (America/Los_Angeles)', function() {
+					test('utcdatetime is converted to UTC from the given timezone (America/Los_Angeles)', function(done) {
 						htmlElem.setAttribute('data-timezone', JSON.stringify({ name: '', identifier: 'America/Los_Angeles' }));
-						const element = fixture('basic');
-						element.date = '1990-01-30';
-						element.hours = 1;
-						element.minutes = 30;
-
 						setTimeout(() => {
+							const element = fixture('basic');
+							element.date = '1990-01-30';
+							element.hours = 1;
+							element.minutes = 30;
+
 							expect(element.datetime.utc().hours()).to.equal(9);
 							expect(element.datetime.utc().minutes()).to.equal(30);
 							expect(element.datetime.utc().date()).to.equal(30);
+							done();
 						}, 0);
 					});
 


### PR DESCRIPTION
Enables error state styling, aka red border around the date and time inputs, and a tooltip on hover/focus.

This is controlled by the following new attributes:
- `invalid`, string: Acts as the error state toggle, and provides the term to be displayed in the error tooltip.
- `position`, string: Optional position of the tooltip. Defaults to `bottom`.
- `tooltip-red`: Optional attribute that makes the tooltip appear in red (cinnabar).